### PR TITLE
feat: implement page transitions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": ["next/core-web-vitals"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "warn"
+    "prettier/prettier": "warn",
+    "react-hooks/exhaustive-deps": 0
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
+import Navbar from '@/components/layout/navbar';
+import { PageAnimation, PageTransitions } from '@/components/transitions';
+
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -16,7 +19,19 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <PageTransitions>
+          <Navbar />
+          <PageAnimation
+            variants={{
+              enter: { opacity: 1 },
+              exit: { opacity: 0, transition: { duration: 2 } },
+            }}
+          >
+            {children}
+          </PageAnimation>
+        </PageTransitions>
+      </body>
     </html>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { PageMotion, usePageTransition } from '@/components/transitions';
+
+export default function Login() {
+  const { navigate } = usePageTransition();
+
+  const navigateHome = () => navigate('push', { href: '/' });
+
+  return (
+    <PageMotion variants={{ enter: { y: 0 }, exit: { y: '-100%' } }}>
+      <div>123213</div>
+      <button onClick={navigateHome}>[Navigate With Animation]</button>
+    </PageMotion>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,12 +5,14 @@ import { PageMotion, usePageTransition } from '@/components/transitions';
 export default function Login() {
   const { navigate } = usePageTransition();
 
-  const navigateHome = () => navigate('push', { href: '/' });
+  const navigate1 = () => navigate('replace', { href: '/' });
+  const navigate2 = () => navigate('replace', { href: 'https://www.google.com' });
 
   return (
     <PageMotion variants={{ enter: { y: 0 }, exit: { y: '-100%' } }}>
       <div>123213</div>
-      <button onClick={navigateHome}>[Navigate With Animation]</button>
+      <button onClick={navigate1}>[Navigate With Animation]</button>
+      <button onClick={navigate2}>[Navigate Thrid Party]</button>
     </PageMotion>
   );
 }

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -11,6 +11,9 @@ export default async function Navbar() {
           <li>
             <Link href="/login">About</Link>
           </li>
+          <li>
+            <Link href="https://www.google.com">Thrid Party</Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default async function Navbar() {
+  return (
+    <header>
+      <nav className="py-8">
+        <ul className="container flex gap-10">
+          <li>
+            <Link href="/">Home</Link>
+          </li>
+          <li>
+            <Link href="/login">About</Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/components/transitions/context.ts
+++ b/components/transitions/context.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react';
+import { TransitionContext } from './types';
+import { noop } from 'lodash-es';
+
+export const Context = createContext<TransitionContext>({
+  pending: false,
+  navigate: noop,
+  controls: {
+    start: async (): Promise<void> => {},
+    set: noop,
+    stop: noop,
+    mount: (): (() => void) => () => {},
+  },
+  routerPath: {
+    current: '/',
+    previous: '/',
+  },
+});

--- a/components/transitions/hooks.ts
+++ b/components/transitions/hooks.ts
@@ -1,0 +1,42 @@
+import { use, useEffect, useMemo, useRef } from 'react';
+import { usePathname, useParams } from 'next/navigation';
+import { Context } from './context';
+
+export const usePreviousValue = <T>(value?: T): T | undefined => {
+  const prevValue = useRef<T>();
+
+  useEffect(() => {
+    prevValue.current = value;
+    return () => {
+      prevValue.current = undefined;
+    };
+  });
+
+  return prevValue.current;
+};
+
+export const useRouterPath = () => {
+  const pathname = usePathname();
+  const params = useParams();
+  const currentRouterPath = useMemo(() => {
+    return Object.entries(params).reduce((path, [paramKey, paramValue]) => {
+      return path.replace(`/${paramValue}`, `/[${paramKey}]`);
+    }, pathname);
+  }, [pathname, params]);
+  const previousRouterPath = usePreviousValue(currentRouterPath);
+
+  return { current: currentRouterPath, previous: previousRouterPath };
+};
+
+export const useIsFirstRender = () => {
+  const isFirstRenderRef = useRef(true);
+
+  if (isFirstRenderRef.current) {
+    isFirstRenderRef.current = false;
+    return true;
+  }
+
+  return isFirstRenderRef.current;
+};
+
+export const usePageTransition = () => use(Context);

--- a/components/transitions/index.tsx
+++ b/components/transitions/index.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { MouseEventHandler, useCallback, useEffect, useMemo, useTransition } from 'react';
+import { AnimatePresence, motion, useAnimationControls } from 'framer-motion';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  NavigateFn,
+  NextRouteImpl,
+  PageAnimationProps,
+  PageTransitionProps,
+  VanillaTagName,
+} from './types';
+import { useIsFirstRender, usePageTransition, useRouterPath } from './hooks';
+import { Context } from './context';
+
+export * from './hooks';
+export * from './types';
+
+export const PageTransitions = <TagName extends VanillaTagName>(
+  props: PageTransitionProps<TagName>,
+) => {
+  const { children, as, ...rest } = props;
+  const controls = useAnimationControls();
+  const [pending, start] = useTransition();
+  const router = useRouter();
+  const routerPath = useRouterPath();
+  const pathname = usePathname();
+
+  const navigate: NavigateFn = useCallback(
+    (type, { href, options }) => {
+      if (pathname === href) {
+        return;
+      }
+      start(async () => {
+        router[type](href, options);
+        await controls.start('exit');
+      });
+    },
+    [pathname, controls],
+  );
+
+  const onClick: MouseEventHandler<HTMLDivElement> = (e) => {
+    const a = (e.target as Element).closest('a');
+    if (a) {
+      e.preventDefault();
+      const href = a.getAttribute('href') as NextRouteImpl;
+      if (href) {
+        navigate('push', { href });
+      }
+    }
+  };
+
+  const Motion = useMemo(() => {
+    return motion(as || 'div');
+  }, [as]);
+
+  return (
+    <Context.Provider value={{ pending, navigate, controls, routerPath }}>
+      <Motion onClickCapture={onClick} {...rest}>
+        {children}
+      </Motion>
+    </Context.Provider>
+  );
+};
+
+export function PageAnimation<TagName extends VanillaTagName>(props: PageAnimationProps<TagName>) {
+  const { as, ...rest } = props;
+
+  const isFirstRender = useIsFirstRender();
+  const { controls, pending, routerPath } = usePageTransition();
+
+  const Motion = useMemo(() => motion(as || 'div'), [as]);
+
+  useEffect(() => {
+    if (pending || isFirstRender) {
+      return;
+    }
+    controls.start('enter');
+  }, [pending, isFirstRender]);
+
+  return (
+    <AnimatePresence initial={false}>
+      <Motion
+        key={routerPath.current}
+        initial="exit"
+        custom={routerPath}
+        animate={controls}
+        {...rest}
+      />
+    </AnimatePresence>
+  );
+}
+
+export function PageMotion<TagName extends VanillaTagName>(props: PageAnimationProps<TagName>) {
+  const { children, as, ...rest } = props;
+
+  const { routerPath } = usePageTransition();
+
+  const Motion = useMemo(() => motion(as || 'div'), [as]);
+
+  return (
+    <Motion custom={routerPath} {...rest}>
+      {children}
+    </Motion>
+  );
+}

--- a/components/transitions/index.tsx
+++ b/components/transitions/index.tsx
@@ -12,6 +12,7 @@ import {
 } from './types';
 import { useIsFirstRender, usePageTransition, useRouterPath } from './hooks';
 import { Context } from './context';
+import { isExternalUrl } from './utils';
 
 export * from './hooks';
 export * from './types';
@@ -31,6 +32,10 @@ export const PageTransitions = <TagName extends VanillaTagName>(
       if (pathname === href) {
         return;
       }
+      if (isExternalUrl(href)) {
+        router.push(href, options);
+        return;
+      }
       start(async () => {
         router[type](href, options);
         await controls.start('exit');
@@ -45,14 +50,12 @@ export const PageTransitions = <TagName extends VanillaTagName>(
       e.preventDefault();
       const href = a.getAttribute('href') as NextRouteImpl;
       if (href) {
-        navigate('push', { href });
+        navigate('replace', { href });
       }
     }
   };
 
-  const Motion = useMemo(() => {
-    return motion(as || 'div');
-  }, [as]);
+  const Motion = useMemo(() => motion(as || 'div'), [as]);
 
   return (
     <Context.Provider value={{ pending, navigate, controls, routerPath }}>

--- a/components/transitions/types.ts
+++ b/components/transitions/types.ts
@@ -1,0 +1,41 @@
+import { HTMLMotionProps, Target, TargetAndTransition, useAnimationControls } from 'framer-motion';
+import { useRouterPath } from './hooks';
+import {
+  AppRouterInstance,
+  NavigateOptions,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
+export type TransitionContext = {
+  pending: boolean;
+  navigate: NavigateFn;
+  controls: ReturnType<typeof useAnimationControls>;
+  routerPath: ReturnType<typeof useRouterPath>;
+};
+
+export type NavigateType = 'push' | 'replace';
+export type NavigateArgs = { href: NextRouteImpl; options?: NavigateOptions };
+
+export type NavigateFn = (type: NavigateType, args: NavigateArgs) => void;
+
+export type RouterPath = ReturnType<typeof useRouterPath>;
+export type VanillaTagName = keyof HTMLElementTagNameMap;
+
+export type PageResolver = (
+  routerPath: RouterPath,
+  current: Target,
+  velocity: Target,
+) => TargetAndTransition | string;
+export type PageVariant = TargetAndTransition | PageResolver;
+export type PageVariants = { enter: PageVariant; exit: PageVariant };
+
+export type PageAnimationProps<TagName extends VanillaTagName> = Omit<
+  HTMLMotionProps<TagName>,
+  'initial' | 'exit' | 'animate' | 'custom'
+> & { as?: TagName; variants: PageVariants };
+
+export type PageTransitionProps<TagName extends VanillaTagName> = Omit<
+  HTMLMotionProps<TagName>,
+  'onClickCapture'
+> & { as?: TagName };
+
+export type NextRouteImpl = __next_route_internal_types__.RouteImpl<string>;

--- a/components/transitions/types.ts
+++ b/components/transitions/types.ts
@@ -12,7 +12,13 @@ export type TransitionContext = {
   routerPath: ReturnType<typeof useRouterPath>;
 };
 
-export type NavigateType = 'push' | 'replace';
+// `NavigateType` is defined as 'replace' only. This restriction is due to the behavior of
+// browsers when performing forward and backward navigation, which can cause page transitions
+// to behave inconsistently.
+// TODO: 'push' navigation.
+export type NavigateType = 'replace';
+// export type NavigateType = 'push' | 'replace';
+
 export type NavigateArgs = { href: NextRouteImpl; options?: NavigateOptions };
 
 export type NavigateFn = (type: NavigateType, args: NavigateArgs) => void;

--- a/components/transitions/utils.ts
+++ b/components/transitions/utils.ts
@@ -1,0 +1,6 @@
+import { NextRouteImpl } from '.';
+
+export const isExternalUrl = (href: NextRouteImpl) => {
+  const pattern = /^(http:\/\/|https:\/\/)/;
+  return pattern.test(href);
+};

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "clsx": "^2.1.0",
     "dayjs": "^1.11.10",
     "framer-motion": "^11.0.20",
+    "lodash-es": "^4.17.21",
     "next": "14.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.11.30",
     "@types/react": "^18.2.67",
     "@types/react-dom": "^18.2.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   framer-motion:
     specifier: ^11.0.20
     version: 11.0.20(react-dom@18.2.0)(react@18.2.0)
+  lodash-es:
+    specifier: ^4.17.21
+    version: 4.17.21
   next:
     specifier: 14.1.4
     version: 14.1.4(react-dom@18.2.0)(react@18.2.0)
@@ -28,6 +31,9 @@ dependencies:
     version: 18.2.0(react@18.2.0)
 
 devDependencies:
+  '@types/lodash-es':
+    specifier: ^4.17.12
+    version: 4.17.12
   '@types/node':
     specifier: ^20.11.30
     version: 20.11.30
@@ -386,6 +392,16 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.17.0
+    dev: true
+
+  /@types/lodash@4.17.0:
+    resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
     dev: true
 
   /@types/node@20.11.30:
@@ -2194,6 +2210,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
+
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}


### PR DESCRIPTION
This PR resolves the main problem mentioned in #3 

**Notable limitation:**
Default support for 'replace' navigate ONLY due to browser's forward and backward operations potentially breaking the transitions.